### PR TITLE
Fix Python worker CORS header create_response syntax error

### DIFF
--- a/src/workers/main.py
+++ b/src/workers/main.py
@@ -32,9 +32,10 @@ def get_cors_headers(origin):
 
 def create_response(data, status=200, origin=None):
     """Create a JSON response with CORS headers"""
+    cors_headers = get_cors_headers(origin) if origin else {}
     headers = {
         'Content-Type': 'application/json',
-        **get_cors_headers(origin) if origin else {},
+        **cors_headers,
     }
     
     return Response.new(


### PR DESCRIPTION
Closes #4 
### Summary

- Move conditional CORS header logic out of the dict literal in `create_response` to resolve the invalid `** ... if ... else ...` syntax.
- Ensure JSON responses always include `Content-Type` and optionally merge CORS headers when an `Origin` is provided.

### Detailes

- The previous pattern `**get_cors_headers(origin) if origin else {}` is invalid in Python and prevented the worker module from importing, breaking all routes.
- The fix pre-computes/merges CORS headers before building the headers dict, maintaining behavior while restoring valid syntax. 

<img width="1920" height="1020" alt="Screenshot 2026-02-19 204418" src="https://github.com/user-attachments/assets/602308bc-58dc-4cee-9951-d383e7135056" />
