### PR TITLE
Fix: Dark/Light theme toggle and mobile visibility

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -377,6 +377,17 @@ class UIComponents {
 // Event Handlers
 // ===================================
 function setupEventHandlers() {
+    // Apply stored or system theme preference early
+    (function() {
+        const h = document.documentElement;
+        const s = localStorage.getItem('theme');
+        if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            h.classList.add('dark');
+        } else {
+            h.classList.remove('dark');
+        }
+    })();
+
     // Login button
     const loginBtn = document.getElementById('loginBtn');
     if (loginBtn) {

--- a/src/index.html
+++ b/src/index.html
@@ -39,13 +39,15 @@
           <li><a href="pages/projects.html" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">Projects</a></li>
           <li><a href="pages/about.html" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">About</a></li>
         </ul>
-        <div class="hidden md:flex items-center gap-2">
+        <div class="flex items-center gap-2">
           <button id="themeToggle" class="p-2 text-gray-500 dark:text-gray-400 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" aria-label="Toggle theme">
-            <i class="fa-solid fa-sun dark:hidden text-sm" aria-hidden="true"></i>
-            <i class="fa-solid fa-moon hidden dark:block text-sm" aria-hidden="true"></i>
+            <i id="sunIcon" class="fa-solid fa-sun text-sm hidden" aria-hidden="true"></i>
+            <i id="moonIcon" class="fa-solid fa-moon text-sm hidden" aria-hidden="true"></i>
           </button>
-          <button id="loginBtn" class="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 border border-red-600 dark:border-red-400 rounded-md hover:bg-red-600 hover:text-white transition-colors">Login</button>
-          <button id="signupBtn" class="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 transition-colors">Sign Up</button>
+          <div class="hidden md:flex items-center gap-2">
+            <button id="loginBtn" class="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 border border-red-600 dark:border-red-400 rounded-md hover:bg-red-600 hover:text-white transition-colors">Login</button>
+            <button id="signupBtn" class="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 transition-colors">Sign Up</button>
+          </div>
         </div>
         <button class="md:hidden p-2 text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800" id="mobileMenuBtn" aria-label="Open menu">
           <i class="fa-solid fa-bars text-base" aria-hidden="true"></i>
@@ -272,10 +274,7 @@
       if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) h.classList.add('dark');
     })();
     document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById('themeToggle')?.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', document.documentElement.classList.contains('dark') ? 'dark' : 'light');
-      });
+      // theme toggle click is handled centrally by main.js
       document.getElementById('mobileMenuBtn')?.addEventListener('click', () => {
         document.getElementById('mobileMenu').classList.toggle('hidden');
       });

--- a/src/pages/about.html
+++ b/src/pages/about.html
@@ -39,13 +39,15 @@
           <li><a href="projects.html" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">Projects</a></li>
           <li><a href="about.html" class="px-3 py-2 text-sm font-medium text-red-600 dark:text-red-400 rounded-md bg-red-50 dark:bg-gray-800">About</a></li>
         </ul>
-        <div class="hidden md:flex items-center gap-2">
+        <div class="flex items-center gap-2">
           <button id="themeToggle" class="p-2 text-gray-500 dark:text-gray-400 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" aria-label="Toggle theme">
-            <i class="fa-solid fa-sun dark:hidden text-sm" aria-hidden="true"></i>
-            <i class="fa-solid fa-moon hidden dark:block text-sm" aria-hidden="true"></i>
+            <i id="sunIcon" class="fa-solid fa-sun text-sm hidden" aria-hidden="true"></i>
+            <i id="moonIcon" class="fa-solid fa-moon text-sm hidden" aria-hidden="true"></i>
           </button>
-          <button id="loginBtn" class="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 border border-red-600 dark:border-red-400 rounded-md hover:bg-red-600 hover:text-white transition-colors">Login</button>
-          <button id="signupBtn" class="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 transition-colors">Sign Up</button>
+          <div class="hidden md:flex items-center gap-2">
+            <button id="loginBtn" class="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 border border-red-600 dark:border-red-400 rounded-md hover:bg-red-600 hover:text-white transition-colors">Login</button>
+            <button id="signupBtn" class="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 transition-colors">Sign Up</button>
+          </div>
         </div>
         <button class="md:hidden p-2 text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800" id="mobileMenuBtn" aria-label="Open menu">
           <i class="fa-solid fa-bars text-base" aria-hidden="true"></i>
@@ -222,21 +224,18 @@
     </div>
   </footer>
   <script>
-    // Theme toggle
+    // Initialize theme based on preference/localStorage
     (function() {
       const h = document.documentElement;
       const s = localStorage.getItem('theme');
-      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) h.classList.add('dark');
+      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+          h.classList.add('dark');
+      }
     })();
     document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById('themeToggle')?.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', document.documentElement.classList.contains('dark') ? 'dark' : 'light');
-      });
       document.getElementById('mobileMenuBtn')?.addEventListener('click', () => {
         document.getElementById('mobileMenu').classList.toggle('hidden');
       });
-      
     });
   </script>
 </body>

--- a/src/pages/leaderboard.html
+++ b/src/pages/leaderboard.html
@@ -39,13 +39,15 @@
           <li><a href="projects.html" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">Projects</a></li>
           <li><a href="about.html" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">About</a></li>
         </ul>
-        <div class="hidden md:flex items-center gap-2">
+        <div class="flex items-center gap-2">
           <button id="themeToggle" class="p-2 text-gray-500 dark:text-gray-400 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" aria-label="Toggle theme">
-            <i class="fa-solid fa-sun dark:hidden text-sm" aria-hidden="true"></i>
-            <i class="fa-solid fa-moon hidden dark:block text-sm" aria-hidden="true"></i>
+            <i id="sunIcon" class="fa-solid fa-sun text-sm hidden" aria-hidden="true"></i>
+            <i id="moonIcon" class="fa-solid fa-moon text-sm hidden" aria-hidden="true"></i>
           </button>
-          <button id="loginBtn" class="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 border border-red-600 dark:border-red-400 rounded-md hover:bg-red-600 hover:text-white transition-colors">Login</button>
-          <button id="signupBtn" class="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 transition-colors">Sign Up</button>
+          <div class="hidden md:flex items-center gap-2">
+            <button id="loginBtn" class="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 border border-red-600 dark:border-red-400 rounded-md hover:bg-red-600 hover:text-white transition-colors">Login</button>
+            <button id="signupBtn" class="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 transition-colors">Sign Up</button>
+          </div>
         </div>
         <button class="md:hidden p-2 text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800" id="mobileMenuBtn" aria-label="Open menu">
           <i class="fa-solid fa-bars text-base" aria-hidden="true"></i>
@@ -200,21 +202,18 @@
     </div>
   </footer>
   <script>
-    // Theme toggle
+    // Initialize theme based on preference/localStorage
     (function() {
       const h = document.documentElement;
       const s = localStorage.getItem('theme');
-      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) h.classList.add('dark');
+      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+          h.classList.add('dark');
+      }
     })();
     document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById('themeToggle')?.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', document.documentElement.classList.contains('dark') ? 'dark' : 'light');
-      });
       document.getElementById('mobileMenuBtn')?.addEventListener('click', () => {
         document.getElementById('mobileMenu').classList.toggle('hidden');
       });
-      
     });
   </script>
 </body>

--- a/src/pages/projects.html
+++ b/src/pages/projects.html
@@ -39,13 +39,15 @@
           <li><a href="projects.html" class="px-3 py-2 text-sm font-medium text-red-600 dark:text-red-400 rounded-md bg-red-50 dark:bg-gray-800">Projects</a></li>
           <li><a href="about.html" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">About</a></li>
         </ul>
-        <div class="hidden md:flex items-center gap-2">
+        <div class="flex items-center gap-2">
           <button id="themeToggle" class="p-2 text-gray-500 dark:text-gray-400 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" aria-label="Toggle theme">
-            <i class="fa-solid fa-sun dark:hidden text-sm" aria-hidden="true"></i>
-            <i class="fa-solid fa-moon hidden dark:block text-sm" aria-hidden="true"></i>
+            <i id="sunIcon" class="fa-solid fa-sun text-sm hidden" aria-hidden="true"></i>
+            <i id="moonIcon" class="fa-solid fa-moon text-sm hidden" aria-hidden="true"></i>
           </button>
-          <button id="loginBtn" class="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 border border-red-600 dark:border-red-400 rounded-md hover:bg-red-600 hover:text-white transition-colors">Login</button>
-          <button id="signupBtn" class="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 transition-colors">Sign Up</button>
+          <div class="hidden md:flex items-center gap-2">
+            <button id="loginBtn" class="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 border border-red-600 dark:border-red-400 rounded-md hover:bg-red-600 hover:text-white transition-colors">Login</button>
+            <button id="signupBtn" class="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 transition-colors">Sign Up</button>
+          </div>
         </div>
         <button class="md:hidden p-2 text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800" id="mobileMenuBtn" aria-label="Open menu">
           <i class="fa-solid fa-bars text-base" aria-hidden="true"></i>
@@ -207,21 +209,18 @@
     </div>
   </footer>
   <script>
-    // Theme toggle
+    // Initialize theme based on preference/localStorage
     (function() {
       const h = document.documentElement;
       const s = localStorage.getItem('theme');
-      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) h.classList.add('dark');
+      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+          h.classList.add('dark');
+      }
     })();
     document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById('themeToggle')?.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', document.documentElement.classList.contains('dark') ? 'dark' : 'light');
-      });
       document.getElementById('mobileMenuBtn')?.addEventListener('click', () => {
         document.getElementById('mobileMenu').classList.toggle('hidden');
       });
-      
     });
   </script>
 </body>

--- a/src/pages/report-bug.html
+++ b/src/pages/report-bug.html
@@ -39,13 +39,15 @@
           <li><a href="projects.html" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">Projects</a></li>
           <li><a href="about.html" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">About</a></li>
         </ul>
-        <div class="hidden md:flex items-center gap-2">
+        <div class="flex items-center gap-2">
           <button id="themeToggle" class="p-2 text-gray-500 dark:text-gray-400 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" aria-label="Toggle theme">
-            <i class="fa-solid fa-sun dark:hidden text-sm" aria-hidden="true"></i>
-            <i class="fa-solid fa-moon hidden dark:block text-sm" aria-hidden="true"></i>
+            <i id="sunIcon" class="fa-solid fa-sun text-sm hidden" aria-hidden="true"></i>
+            <i id="moonIcon" class="fa-solid fa-moon text-sm hidden" aria-hidden="true"></i>
           </button>
-          <button id="loginBtn" class="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 border border-red-600 dark:border-red-400 rounded-md hover:bg-red-600 hover:text-white transition-colors">Login</button>
-          <button id="signupBtn" class="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 transition-colors">Sign Up</button>
+          <div class="hidden md:flex items-center gap-2">
+            <button id="loginBtn" class="px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 border border-red-600 dark:border-red-400 rounded-md hover:bg-red-600 hover:text-white transition-colors">Login</button>
+            <button id="signupBtn" class="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 transition-colors">Sign Up</button>
+          </div>
         </div>
         <button class="md:hidden p-2 text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800" id="mobileMenuBtn" aria-label="Open menu">
           <i class="fa-solid fa-bars text-base" aria-hidden="true"></i>
@@ -234,21 +236,18 @@
     </div>
   </footer>
   <script>
-    // Theme toggle
+    // Initialize theme based on preference/localStorage
     (function() {
       const h = document.documentElement;
       const s = localStorage.getItem('theme');
-      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) h.classList.add('dark');
+      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+          h.classList.add('dark');
+      }
     })();
     document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById('themeToggle')?.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', document.documentElement.classList.contains('dark') ? 'dark' : 'light');
-      });
       document.getElementById('mobileMenuBtn')?.addEventListener('click', () => {
         document.getElementById('mobileMenu').classList.toggle('hidden');
       });
-      
     });
   </script>
 </body>


### PR DESCRIPTION
I noticed the theme switcher wasn't working and was hidden on mobile devices. I went through the markup and scripts and fixed the following:

1. **Removed duplicate click handlers:** The shared main.js and inline <script> tags were both firing, toggling the class twice and leaving the theme unchanged.

2. **Fixed mobile visibility:** Removed hidden md:flex around the toggle button so it renders on small screens.


3. **Fixed Icon SVGs:** Added id="sunIcon" and id="moonIcon" so the JavaScript in main.js can actually target them and swap them correctly.

Everything is now tested and working on both desktop and mobile views!