### PR TITLE
Refactor: Remove Redundant Theme Logic Across Multiple Pages

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -16,6 +16,19 @@ const CONFIG = {
     ENABLE_ANALYTICS: true,
 };
 
+function applyThemePreference() {
+    try {
+        const stored = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const shouldUseDark = stored ? stored === 'dark' : prefersDark;
+        document.documentElement.classList.toggle('dark', shouldUseDark);
+    } catch (error) {
+        // Ignore storage access issues and keep default theme.
+    }
+}
+
+applyThemePreference();
+
 // ===================================
 // State Management
 // ===================================
@@ -441,28 +454,10 @@ function setupEventHandlers() {
 
     // Theme Toggle
     const themeToggle = document.getElementById('themeToggle');
-    const sunIcon = document.getElementById('sunIcon');
-    const moonIcon = document.getElementById('moonIcon');
-
-    function updateThemeIcons() {
-        if (!sunIcon || !moonIcon) return;
-        if (document.documentElement.classList.contains('dark')) {
-            sunIcon.classList.remove('hidden');
-            moonIcon.classList.add('hidden');
-        } else {
-            sunIcon.classList.add('hidden');
-            moonIcon.classList.remove('hidden');
-        }
-    }
-
     if (themeToggle) {
-        // Initial icon state
-        updateThemeIcons();
-
         themeToggle.addEventListener('click', () => {
             const isDark = document.documentElement.classList.toggle('dark');
             localStorage.setItem('theme', isDark ? 'dark' : 'light');
-            updateThemeIcons();
 
             // Re-emit theme change for other components
             if (window.bltApp && window.bltApp.state) {

--- a/src/index.html
+++ b/src/index.html
@@ -265,21 +265,11 @@
 
 
   <script>
-    // Theme toggle
-    (function() {
-      const h = document.documentElement;
-      const s = localStorage.getItem('theme');
-      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) h.classList.add('dark');
-    })();
     document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById('themeToggle')?.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', document.documentElement.classList.contains('dark') ? 'dark' : 'light');
-      });
       document.getElementById('mobileMenuBtn')?.addEventListener('click', () => {
         document.getElementById('mobileMenu').classList.toggle('hidden');
       });
-      
+
       const modal = document.getElementById('authModal');
       const modalTitle = document.getElementById('modalTitle');
       document.getElementById('loginBtn')?.addEventListener('click', () => { modalTitle.textContent = 'Sign In'; modal.classList.remove('hidden'); });
@@ -287,7 +277,6 @@
       document.getElementById('ctaSignupBtn')?.addEventListener('click', () => { modalTitle.textContent = 'Create Account'; modal.classList.remove('hidden'); });
       document.getElementById('closeModal')?.addEventListener('click', () => modal.classList.add('hidden'));
       modal?.addEventListener('click', (e) => { if (e.target === modal) modal.classList.add('hidden'); });
-
     });
   </script>
 </body>

--- a/src/pages/about.html
+++ b/src/pages/about.html
@@ -222,21 +222,10 @@
     </div>
   </footer>
   <script>
-    // Theme toggle
-    (function() {
-      const h = document.documentElement;
-      const s = localStorage.getItem('theme');
-      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) h.classList.add('dark');
-    })();
     document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById('themeToggle')?.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', document.documentElement.classList.contains('dark') ? 'dark' : 'light');
-      });
       document.getElementById('mobileMenuBtn')?.addEventListener('click', () => {
         document.getElementById('mobileMenu').classList.toggle('hidden');
       });
-      
     });
   </script>
 </body>

--- a/src/pages/leaderboard.html
+++ b/src/pages/leaderboard.html
@@ -200,21 +200,10 @@
     </div>
   </footer>
   <script>
-    // Theme toggle
-    (function() {
-      const h = document.documentElement;
-      const s = localStorage.getItem('theme');
-      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) h.classList.add('dark');
-    })();
     document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById('themeToggle')?.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', document.documentElement.classList.contains('dark') ? 'dark' : 'light');
-      });
       document.getElementById('mobileMenuBtn')?.addEventListener('click', () => {
         document.getElementById('mobileMenu').classList.toggle('hidden');
       });
-      
     });
   </script>
 </body>

--- a/src/pages/projects.html
+++ b/src/pages/projects.html
@@ -207,21 +207,10 @@
     </div>
   </footer>
   <script>
-    // Theme toggle
-    (function() {
-      const h = document.documentElement;
-      const s = localStorage.getItem('theme');
-      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) h.classList.add('dark');
-    })();
     document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById('themeToggle')?.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', document.documentElement.classList.contains('dark') ? 'dark' : 'light');
-      });
       document.getElementById('mobileMenuBtn')?.addEventListener('click', () => {
         document.getElementById('mobileMenu').classList.toggle('hidden');
       });
-      
     });
   </script>
 </body>

--- a/src/pages/report-bug.html
+++ b/src/pages/report-bug.html
@@ -234,21 +234,10 @@
     </div>
   </footer>
   <script>
-    // Theme toggle
-    (function() {
-      const h = document.documentElement;
-      const s = localStorage.getItem('theme');
-      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme: dark)').matches)) h.classList.add('dark');
-    })();
     document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById('themeToggle')?.addEventListener('click', () => {
-        document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', document.documentElement.classList.contains('dark') ? 'dark' : 'light');
-      });
       document.getElementById('mobileMenuBtn')?.addEventListener('click', () => {
         document.getElementById('mobileMenu').classList.toggle('hidden');
       });
-      
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary

This PR removes duplicated dark/light theme logic from multiple HTML pages and centralizes theme initialization and toggle handling into the shared `main.js` file.

Closes #24
This PR also resolves the unexpected behavior of the theme toggle button (#17).

---

## Changes Made

### Centralized Theme Logic
- Moved theme preference initialization to `main.js`
- Attached `#themeToggle` click handler in `main.js`
- Ensured theme preference persists via `localStorage`

### Removed Redundant Inline Scripts
Removed theme-related inline scripts from:

- `index.html`
- `about.html`
- `projects.html`
- `leaderboard.html`
- `report-bug.html`


## Testing

- Verified theme toggle works correctly on all pages
- Confirmed theme preference persists after reload

---

## Checklist

- [x] No duplicated theme scripts remain
- [x] Theme toggles correctly across all pages
- [x] Theme preference persists
- [x] Resolves #17