### PR TITLE
Improve mobile menu overlay to prevent layout shift

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -51,7 +51,7 @@
           <i class="fa-solid fa-bars text-base" aria-hidden="true"></i>
         </button>
       </nav>
-      <div id="mobileMenu" class="hidden md:hidden fixed top-16 left-0 w-full z-40 px-4 pb-4 border-t border-[#E5E5E5] dark:border-gray-800 dark:bg-gray-900">
+      <div id="mobileMenu" class="hidden md:hidden fixed top-16 left-0 w-full h-[calc(100vh-4rem)] z-40 px-4 pb-4 border-t border-[#E5E5E5] dark:border-gray-800 dark:bg-gray-900">
         <ul class="flex flex-col gap-1 pt-3 list-none m-0 p-0">
           <li><a href="index.html" class="block px-3 py-2 text-sm font-medium text-red-600 dark:text-red-400 rounded-md bg-red-50 dark:bg-gray-800">Home</a></li>
           <li><a href="pages/report-bug.html" class="block px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">Report Bug</a></li>

--- a/src/pages/about.html
+++ b/src/pages/about.html
@@ -51,7 +51,7 @@
           <i class="fa-solid fa-bars text-base" aria-hidden="true"></i>
         </button>
       </nav>
-      <div id="mobileMenu" class="hidden md:hidden fixed top-16 left-0 w-full z-40 px-4 pb-4 border-t border-[#E5E5E5] dark:border-gray-800 dark:bg-gray-900">
+      <div id="mobileMenu" class="hidden md:hidden fixed top-16 left-0 w-full h-[calc(100vh-4rem)] z-40 px-4 pb-4 border-t border-[#E5E5E5] dark:border-gray-800 dark:bg-gray-900">
         <ul class="flex flex-col gap-1 pt-3 list-none m-0 p-0">
           <li><a href="../index.html" class="block px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">Home</a></li>
           <li><a href="report-bug.html" class="block px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">Report Bug</a></li>

--- a/src/pages/leaderboard.html
+++ b/src/pages/leaderboard.html
@@ -51,7 +51,7 @@
           <i class="fa-solid fa-bars text-base" aria-hidden="true"></i>
         </button>
       </nav>
-      <div id="mobileMenu" class="hidden md:hidden fixed top-16 left-0 w-full z-40 px-4 pb-4 border-t border-[#E5E5E5] dark:border-gray-800 dark:bg-gray-900">
+      <div id="mobileMenu" class="hidden md:hidden fixed top-16 left-0 w-full h-[calc(100vh-4rem)] z-40 px-4 pb-4 border-t border-[#E5E5E5] dark:border-gray-800 dark:bg-gray-900">
         <ul class="flex flex-col gap-1 pt-3 list-none m-0 p-0">
           <li><a href="../index.html" class="block px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">Home</a></li>
           <li><a href="report-bug.html" class="block px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">Report Bug</a></li>

--- a/src/pages/projects.html
+++ b/src/pages/projects.html
@@ -51,7 +51,7 @@
           <i class="fa-solid fa-bars text-base" aria-hidden="true"></i>
         </button>
       </nav>
-      <div id="mobileMenu" class="hidden md:hidden fixed top-16 left-0 w-full z-40 px-4 pb-4 border-t border-[#E5E5E5] dark:border-gray-800 dark:bg-gray-900">
+      <div id="mobileMenu" class="hidden md:hidden fixed top-16 left-0 w-full h-[calc(100vh-4rem)] z-40 px-4 pb-4 border-t border-[#E5E5E5] dark:border-gray-800 dark:bg-gray-900">
         <ul class="flex flex-col gap-1 pt-3 list-none m-0 p-0">
           <li><a href="../index.html" class="block px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">Home</a></li>
           <li><a href="report-bug.html" class="block px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">Report Bug</a></li>

--- a/src/pages/report-bug.html
+++ b/src/pages/report-bug.html
@@ -51,7 +51,7 @@
           <i class="fa-solid fa-bars text-base" aria-hidden="true"></i>
         </button>
       </nav>
-      <div id="mobileMenu" class="hidden md:hidden fixed top-16 left-0 w-full z-40 px-4 pb-4 border-t border-[#E5E5E5] dark:border-gray-800 dark:bg-gray-900">
+      <div id="mobileMenu" class="hidden md:hidden fixed top-16 left-0 w-full h-[calc(100vh-4rem)] z-40 px-4 pb-4 border-t border-[#E5E5E5] dark:border-gray-800 dark:bg-gray-900">
         <ul class="flex flex-col gap-1 pt-3 list-none m-0 p-0">
           <li><a href="../index.html" class="block px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 rounded-md hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-gray-800 transition-colors">Home</a></li>
           <li><a href="report-bug.html" class="block px-3 py-2 text-sm font-medium text-red-600 dark:text-red-400 rounded-md bg-red-50 dark:bg-gray-800">Report Bug</a></li>


### PR DESCRIPTION
This PR improves the mobile menu behavior by preventing layout shift when the menu is opened.

The menu positioning has been updated to use **position: fixed** with full overlay height **(h-[calc(100vh-4rem)])** so it no longer affects the document flow.
- Header remains sticky
- No content shifting
- Improved mobile UX

This follows the preferred approach discussed in the issue.

Closes #23