### PR TITLE
ux: add visual indicators to severity dropdown for better scannability

### DIFF
--- a/src/pages/report-bug.html
+++ b/src/pages/report-bug.html
@@ -112,11 +112,11 @@
                   <select id="bugSeverity" name="severity" required
                     class="w-full px-4 py-2.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:border-red-600 focus:ring-1 focus:ring-red-600 transition-colors appearance-none">
                     <option value="" disabled selected>Select severity</option>
-                    <option value="critical">Critical</option>
-                    <option value="high">High</option>
-                    <option value="medium">Medium</option>
-                    <option value="low">Low</option>
-                    <option value="info">Informational</option>
+                    <option value="critical">🔴 Critical</option>
+                    <option value="high">🟠 High</option>
+                    <option value="medium">🟡 Medium</option>
+                    <option value="low">🟢 Low</option>
+                    <option value="info">ℹ️ Informational</option>
                   </select>
                 </div>
                 <div>


### PR DESCRIPTION
I have added color-coded icons (🔴, 🟠, 🟡, 🟢, ℹ️) to the Severity dropdown in report-bug.html. This improves visual hierarchy and aligns the dropdown with the existing Severity Guide in the sidebar. No external dependencies were added.