### PR TITLE
fix: correct wrangler.toml path and deploy commands in deployment.md …

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -294,7 +294,7 @@ jobs:
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          workingDirectory: 'src/workers'
+          workingDirectory: '.'
 ```
 
 Add `CLOUDFLARE_API_TOKEN` to repository secrets.


### PR DESCRIPTION
…(closes #56)## Summary
Fixes #56

`docs/deployment.md` referenced `src/workers/wrangler.toml` 
and instructed contributors to run `cd src/workers` before 
deploying, but `wrangler.toml` lives in the project root.

Any contributor following the deployment guide would get:
error: No config file found!
## Changes
Fixed 5 incorrect references in `docs/deployment.md`:
- Line 82: `src/workers/wrangler.toml` → `wrangler.toml`
- Line 111: `src/workers/wrangler.toml` → `wrangler.toml`
- Lines 120-121: removed `cd src/workers`
- Lines 169-170: removed `cd src/workers`
- Lines 275-276: removed `cd src/workers`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guide to use root-level configuration and to run deployments from the project root.
  * Removed prior instructions requiring changing into a subdirectory before deploying.
  * CI workflow guidance revised to run from the repository root rather than a nested folder.
  * Minor wording edits for clarity and reduced potential confusion during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->