### PR TITLE
Fix leaderboard pagination buttons not working

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -698,7 +698,7 @@ document.addEventListener("htmx:afterSwap", () => {
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll(".page-btn").forEach((btn) => {
     btn.addEventListener("click", () => {
-      const page = parseInt(btn.textContent.trim());
+      const page = parseInt(btn.dataset.page);
       if (!isNaN(page)) {
         currentPage = page;
         updateLeaderboardPagination();

--- a/src/pages/leaderboard.html
+++ b/src/pages/leaderboard.html
@@ -172,9 +172,9 @@
             <button id="prev-page" class="p-1.5 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-30 transition-colors">
               <i class="fa-solid fa-chevron-left text-xs" aria-hidden="true"></i>
             </button>
-            <button class="page-btn w-7 h-7 text-xs font-medium text-white bg-red-600 rounded-md">1</button>
-            <button class="page-btn w-7 h-7 text-xs font-medium text-gray-600 dark:text-gray-300 border border-[#E5E5E5] dark:border-gray-700 rounded-md hover:border-red-600 hover:text-red-600 dark:hover:text-red-400 transition-colors">2</button>
-            <button class="page-btn w-7 h-7 text-xs font-medium text-gray-600 dark:text-gray-300 border border-[#E5E5E5] dark:border-gray-700 rounded-md hover:border-red-600 hover:text-red-600 dark:hover:text-red-400 transition-colors">3</button>
+            <button class="page-btn w-7 h-7 text-xs font-medium text-white bg-red-600 rounded-md" data-page="1">1</button>
+            <button class="page-btn w-7 h-7 text-xs font-medium text-gray-600 dark:text-gray-300 border border-[#E5E5E5] dark:border-gray-700 rounded-md hover:border-red-600 hover:text-red-600 dark:hover:text-red-400 transition-colors" data-page="2">2</button>
+            <button class="page-btn w-7 h-7 text-xs font-medium text-gray-600 dark:text-gray-300 border border-[#E5E5E5] dark:border-gray-700 rounded-md hover:border-red-600 hover:text-red-600 dark:hover:text-red-400 transition-colors" data-page="3">3</button>
             <span class="text-xs text-gray-400 dark:text-gray-500 px-1">…</span>
             <button id="next-page" class="p-1.5 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 transition-colors">
               <i class="fa-solid fa-chevron-right text-xs" aria-hidden="true"></i>


### PR DESCRIPTION
Fixes #57 

## Description

This PR fixes the issue where leaderboard pagination buttons were not updating the displayed researchers.

Previously, the leaderboard table only displayed the first 5 researchers and clicking pagination buttons did not load the next set of researchers.

## Changes Made

-Fixed leaderboard pagination button functionality
-Updated pagination display logic for the leaderboard

## Testing

-Verified pagination buttons respond correctly when clicked
-Confirmed page numbers update and highlight correctly

## Screenshots

<img width="686" height="113" alt="image" src="https://github.com/user-attachments/assets/1b108db0-5420-4290-b71a-3d1bb7560788" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Leaderboard pagination added: numbered page controls plus Next/Previous navigation, with active-page highlighting and bounds handling.
  * Pagination info displayed (current range/page) for clearer orientation when browsing large researcher lists.
  * Pagination UI reliably refreshes after dynamic content updates to maintain consistent navigation state.
  * Row markup standardized for more consistent styling and interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->