### PR TITLE
feat: create profile.html page for authenticated users

### DIFF
--- a/src/pages/profile.html
+++ b/src/pages/profile.html
@@ -219,9 +219,10 @@
     });
 
     function populateProfile(user) {
+      // Use null/undefined check to preserve valid zero values
       const setEl = (id, val) => {
         const el = document.getElementById(id);
-        if (el) el.textContent = val || '—';
+        if (el) el.textContent = (val != null && val !== '') ? val : '—';
       };
 
       setEl('profileUsername', user.username);
@@ -245,7 +246,11 @@
     async function loadBugReports(user) {
       const tbody = document.getElementById('bugReportsTable');
       try {
-        const res = await fetch('/api/bugs?reporter=' + (user.id || ''));
+        // Note: server-side reporter scoping is tracked in a separate issue.
+        // This request passes the authenticated user's id as a hint.
+        const res = await fetch('/api/bugs?reporter=' + encodeURIComponent(user.id || ''), {
+          headers: { 'Authorization': 'Bearer ' + (localStorage.getItem('access_token') || '') }
+        });
         const data = await res.json();
         const bugs = data.bugs || data.data || [];
 


### PR DESCRIPTION
## Summary
Closes #73

## Changes

### `src/pages/profile.html` (new file)
- Matches existing design system (Tailwind, dark mode, 
  Inter font, Font Awesome, consistent navbar/footer)
- Auth guard — redirects unauthenticated users to home
- Displays username, email, avatar initial from auth state
- Shows bugs reported, points earned, global rank stats
- Bug reports table with status, severity, and date
- Logout button
- All asset paths are absolute (/assets/...) for correct 
  resolution from any URL

### `src/assets/js/main.js`
- No net change against upstream main — both this branch 
  and origin/main use `/pages/profile.html` (absolute path)
- The absolute path correctly resolves from any page, 
  including nested /pages/* routes

## Testing
Navigate to /pages/profile.html while logged in — 
profile data loads from auth state. Navigate while 
logged out — redirects to home.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user profile page displaying account info (username, email, avatar).
  * Introduced profile statistics: bugs reported, points earned, global rank.
  * Added a bug reports table with status-based styling, empty-state and loading behavior.
  * Integrated authentication guard requiring login to view profile; includes logout flow.
  * Included theme toggle and persisted theme selection; improved mobile-responsive navbar.
  * Accessibility improvements (ARIA labels, semantic structure) and error fallback for data loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->