### PR TITLE
fix: auth API endpoints missing /api prefix causing 404 on all auth requests (closes #67)

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -147,7 +147,7 @@ class AuthModule {
 
     async login(email, password) {
         try {
-            const response = await this.api.post('/auth/login', { email, password });
+            const response = await this.api.post('/api/auth/login', { email, password });
 
             if (response.token) {
                 localStorage.setItem('authToken', response.token);
@@ -163,7 +163,7 @@ class AuthModule {
 
     async signup(userData) {
         try {
-            const response = await this.api.post('/auth/signup', userData);
+            const response = await this.api.post('/api/auth/signup', userData);
 
             if (response.token) {
                 localStorage.setItem('authToken', response.token);
@@ -179,7 +179,7 @@ class AuthModule {
 
     async logout() {
         try {
-            await this.api.post('/auth/logout', {});
+            await this.api.post('/api/auth/logout', {});
         } catch (error) {
             console.error('Logout error:', error);
         } finally {
@@ -196,7 +196,7 @@ class AuthModule {
         }
 
         try {
-            const response = await this.api.get('/auth/me');
+            const response = await this.api.get('/api/auth/me');
             if (response.user) {
                 this.state.setUser(response.user);
                 return true;


### PR DESCRIPTION
Closes #67

## Problem
Four authentication endpoints in `src/assets/js/main.js` are 
missing the `/api` prefix, causing all auth requests to return 
404 errors.

## Current Behavior
The following endpoints are incorrectly defined:
```js
/auth/login
/auth/signup  
/auth/logout
/auth/me
Expected Behavior
All auth endpoints should include the /api prefix:
/api/auth/login
/api/auth/signup
/api/auth/logout
/api/auth/me
Root Cause
In src/assets/js/main.js, the API calls for authentication
use paths without the /api prefix, while the worker routes
in workers/main.py are registered under /api/auth/....
Files Affected
src/assets/js/main.js
Impact
Login fails silently — users cannot sign in
Signup returns 404
Auth state never initializes
All authenticated features broken
