### PR TITLE
Fix/cors missing localhost 8787 issue 79

### DIFF
--- a/workers/main.py
+++ b/workers/main.py
@@ -11,6 +11,7 @@ ALLOWED_ORIGINS = [
     'https://owasp-blt.github.io',
     'http://localhost:3000',
     'http://localhost:8000',
+    'http://localhost:8787',  # default wrangler dev port
 ]
 
 FRONTEND_SECURITY_HEADERS = {


### PR DESCRIPTION
## Summary
Fixes #79

## Changes

### 1. Add localhost:8787 to ALLOWED_ORIGINS
`CONTRIBUTING.md` documents the dev server runs at 
`http://localhost:8787` but it was missing from 
`ALLOWED_ORIGINS`, causing CORS errors for all 
local developers.

### 2. Fix wildcard CORS in handle_html_response
`handle_html_response` was using hardcoded `*` for 
`Access-Control-Allow-Origin`, bypassing the 
`ALLOWED_ORIGINS` allowlist entirely for all HTML 
responses (`/api/stats`, `/api/leaderboard`, 
`/api/projects`, `/api/bugs` POST).

Updated to use `get_cors_headers(origin)` for 
consistent and secure CORS handling.

## Files Changed
- `workers/main.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed login button redirect to properly navigate to the profile page
  * Enhanced CORS configuration for HTML responses with per-origin header handling and local development environment support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->