### PR TITLE
Fix/leaderboard xss missing html escape issue 80

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -492,7 +492,7 @@ function updateUIForAuth() {
         if (loginBtn) {
             loginBtn.textContent = user.username;
             loginBtn.onclick = () => {
-                window.location.href = 'pages/profile.html';
+                window.location.href = '/pages/profile.html';
             };
         }
         if (signupBtn) {


### PR DESCRIPTION
Fixes #80

## Problem
`workers/main.py` leaderboard handler rendered all 
database fields directly into HTML with no escaping 
and `import html` was missing entirely:

```python
f'<div class="rank">{item.rank}</div>'
f'<div class="username">{item.username}</div>'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed login button navigation for authenticated users so it redirects correctly.
  * Strengthened HTML escaping across pages (leaderboard, stats, projects, general responses) to prevent injection and ensure safe display.
  * Improved cross-origin response handling to reduce issues with served pages and embedded content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->