### PR TITLE
Fix/cors preflight dict headers issue 82

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -492,7 +492,7 @@ function updateUIForAuth() {
         if (loginBtn) {
             loginBtn.textContent = user.username;
             loginBtn.onclick = () => {
-                window.location.href = 'pages/profile.html';
+                window.location.href = '/pages/profile.html';
             };
         }
         if (signupBtn) {


### PR DESCRIPTION
## Summary
Fixes #82

## Problem
`handle_cors_preflight` was passing a Python dict 
directly to `Headers.new()`:

```python
headers=Headers.new(get_cors_headers(origin))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile page navigation to use relative routing, improving page transitions and correct behavior across hosting setups.

* **Refactor**
  * Improved backend handling of CORS preflight responses to increase reliability of cross-origin requests while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->