### PR TITLE
Fix/error leakage str exception issue 84

### DIFF
--- a/workers/main.py
+++ b/workers/main.py
@@ -163,7 +163,8 @@ async def handle_stats(request, env=None):
         return handle_html_response(html, origin=request.headers.get('Origin'))
     except Exception as e:
         print(f"D1 Query Error: {e}")
-        return create_response({'error': str(e)}, status=500, origin=request.headers.get('Origin'))
+        print(f'Internal error: {e}')
+            return create_response({'error': 'Internal server error. Please try again.'}, status=500, origin=request.headers.get('Origin'))
 
 async def handle_auth_login(request, env=None):
     """Handle /api/auth/login endpoint"""
@@ -194,9 +195,11 @@ async def handle_auth_login(request, env=None):
         }, status=401, origin=request.headers.get('Origin'))
         
     except Exception as e:
+        print(f'Auth error: {e}')
         return create_response({
             'success': False,
-            'error': str(e)
+            'error': 'Internal server error. Please try again.'
+
         }, status=400, origin=request.headers.get('Origin'))
 
 async def handle_auth_signup(request, env=None):
@@ -239,9 +242,11 @@ async def handle_auth_signup(request, env=None):
         }, status=400, origin=request.headers.get('Origin'))
         
     except Exception as e:
+        print(f'Auth error: {e}')
         return create_response({
             'success': False,
-            'error': str(e)
+            'error': 'Internal server error. Please try again.'
+
         }, status=400, origin=request.headers.get('Origin'))
 
 async def handle_auth_me(request, env=None):
@@ -317,7 +322,8 @@ async def handle_bugs_list(request, env=None):
             """
             return handle_html_response(html, origin=request.headers.get('Origin'))
         except Exception as e:
-            return create_response({'error': str(e)}, status=500, origin=request.headers.get('Origin'))
+            print(f'Internal error: {e}')
+            return create_response({'error': 'Internal server error. Please try again.'}, status=500, origin=request.headers.get('Origin'))
 
     # GET case (list bugs)
     try:
@@ -325,7 +331,8 @@ async def handle_bugs_list(request, env=None):
         bugs = to_dict(results.results)
         return create_response({'bugs': bugs}, origin=request.headers.get('Origin'))
     except Exception as e:
-        return create_response({'error': str(e)}, status=500, origin=request.headers.get('Origin'))
+        print(f'Internal error: {e}')
+            return create_response({'error': 'Internal server error. Please try again.'}, status=500, origin=request.headers.get('Origin'))
 
 async def handle_leaderboard(request, env=None):
     """Handle /api/leaderboard endpoint"""
@@ -365,7 +372,8 @@ async def handle_leaderboard(request, env=None):
         """
         return handle_html_response(html, origin=request.headers.get('Origin'))
     except Exception as e:
-        return create_response({'error': str(e)}, status=500, origin=request.headers.get('Origin'))
+        print(f'Internal error: {e}')
+            return create_response({'error': 'Internal server error. Please try again.'}, status=500, origin=request.headers.get('Origin'))
 
 async def handle_projects(request, env=None):
     """Handle /api/projects endpoint"""
@@ -403,7 +411,8 @@ async def handle_projects(request, env=None):
         ])
         return handle_html_response(cards, origin=request.headers.get('Origin'))
     except Exception as e:
-        return create_response({'error': str(e)}, status=500, origin=request.headers.get('Origin'))
+        print(f'Internal error: {e}')
+            return create_response({'error': 'Internal server error. Please try again.'}, status=500, origin=request.headers.get('Origin'))
 
 # ===================================
 # Router
@@ -470,7 +479,7 @@ class Default(WorkerEntrypoint):
         try:
             return await route_request(request, self.env)
         except Exception as e:
+            print(f'Unhandled error: {type(e).__name__}')
             return create_response({
-                'error': 'Internal server error',
-                'message': str(e)
+                'error': 'Internal server error. Please try again.'
             }, status=500, origin=request.headers.get('Origin'))


### PR DESCRIPTION
## Summary
Fixes #84

## Problem
`workers/main.py` was returning raw exception details 
directly to API clients in 8 places via `str(e)`:

```python
return create_response({'error': str(e)}, status=500)
This exposes internal DB table names, column names,
query structure and stack info to any client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed profile page navigation after login.
  * Standardized error messages across the application for improved consistency and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->