### PR TITLE
fix: resolve JsProxy serialization bug in bug list API

### DIFF
--- a/workers/main.py
+++ b/workers/main.py
@@ -65,6 +65,29 @@ def handle_cors_preflight(origin):
     )
 
 # ===================================
+# Helpers
+# ===================================
+
+def to_dict(obj):
+    """Convert a JsProxy database row or list of rows to plain Python dicts.
+    
+    Cloudflare Workers D1 returns results as JsProxy objects which
+    cannot be serialized by json.dumps(). This helper recursively
+    converts them to native Python types using the .to_py() method.
+    
+    Args:
+        obj: A JsProxy object, list of JsProxy objects, or a plain Python object.
+    
+    Returns:
+        A plain Python dict, list of dicts, or the original object.
+    """
+    if hasattr(obj, 'to_py'):
+        return obj.to_py()
+    if isinstance(obj, list):
+        return [to_dict(item) for item in obj]
+    return obj
+
+# ===================================
 # Route Handlers
 # ===================================
 
@@ -262,7 +285,8 @@ async def handle_bugs_list(request, env=None):
     # GET case (list bugs)
     try:
         results = await env.DB.prepare("SELECT * FROM bugs ORDER BY created_at DESC LIMIT 20").all()
-        return create_response({'bugs': results.results}, origin=request.headers.get('Origin'))
+        bugs = to_dict(results.results)
+        return create_response({'bugs': bugs}, origin=request.headers.get('Origin'))
     except Exception as e:
         return create_response({'error': str(e)}, status=500, origin=request.headers.get('Origin'))
 


### PR DESCRIPTION
# fix: resolve JsProxy serialization bug in D1 database results

### Changes
This PR fixes a critical `500 Internal Server Error` occurring in list-based API endpoints (specifically `GET /api/bugs`).

**The Problem**: 
In the Cloudflare Workers Python environment, D1 database results are returned as `JsProxy` objects. These objects are not directly serializable by Python's `json.dumps()`, causing a crash when generating responses.

**The Solution**: 
- Added a recursive [to_dict](cci:1://file:///d:/USER/BLT-Next/workers/main.py:70:0-87:14) helper function in [workers/main.py](cci:7://file:///d:/USER/BLT-Next/workers/main.py:0:0-0:0). This utility detects `JsProxy` objects and uses their native `.to_py()` method to convert them into native Python dictionaries/lists.
- Updated the [handle_bugs_list](cci:1://file:///d:/USER/BLT-Next/workers/main.py:256:0-290:99) handler to pass database results through this helper before returning the response.

### Verification
**Manual Test (curl)**:
Before fix: `500 Internal Server Error`  
After fix: `200 OK`

**Sample Response**:
```json
{
  "bugs": [
    {
      "id": 1,
      "title": "Test Bug",
      "severity": "low",
      "status": "open",
      "created_at": "2026-03-14 05:06:01"
    }
  ]
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization for the bugs list endpoint so returned results are consistently converted to plain JSON-friendly types before being returned, fixing formatting issues with nested data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->