### PR TITLE
feat: allow dynamic localhost origins for local development #29

### DIFF
--- a/workers/main.py
+++ b/workers/main.py
@@ -22,9 +22,11 @@ def get_cors_headers(origin):
     
     # Check if origin is in allowed list, is a github.io sub-domain, 
     # or is ANY localhost port (Recommended flexible approach for Issue #29)
-    if (origin in ALLOWED_ORIGINS or 
-        origin.endswith('.github.io') or 
+        if (origin in ALLOWED_ORIGINS or 
+        origin.endswith('owasp-blt.github.io') or 
+        origin == 'http://localhost' or
         origin.startswith('http://localhost:')):
+
         
         return {
             'Access-Control-Allow-Origin': origin,


### PR DESCRIPTION
Closes #29. Replaced static origin checks with a dynamic .startswith('http://localhost:') check to support local development on any port (including 8787).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded cross-origin access permissions to include localhost development instances and GitHub Pages-hosted applications alongside existing allowed origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->