### PR TITLE
fix: migrate to modern WorkerEntrypoint class for Cloudflare Python runtime

### DIFF
--- a/workers/main.py
+++ b/workers/main.py
@@ -2,6 +2,7 @@ from js import Response, Headers, URL
 import json
 import hashlib
 from datetime import datetime
+from workers import WorkerEntrypoint #Added this new import to use the modern class-based structure for Cloudflare Workers. 
 
 # ===================================
 # Configuration
@@ -432,12 +433,13 @@ async def route_request(request, env):
 # Main Entry Point
 # ===================================
 
-async def on_fetch(request, env):
-    """Main entry point for Cloudflare Worker"""
-    try:
-        return await route_request(request, env)
-    except Exception as e:
-        return create_response({
-            'error': 'Internal server error',
-            'message': str(e)
-        }, status=500, origin=request.headers.get('Origin'))
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        """Main entry point for Cloudflare Worker"""
+        try:
+            return await route_request(request, self.env)
+        except Exception as e:
+            return create_response({
+                'error': 'Internal server error',
+                'message': str(e)
+            }, status=500, origin=request.headers.get('Origin'))


### PR DESCRIPTION
### Description
Running `npm run dev` locally currently causes a fatal crash for all API routes because the Cloudflare Python runtime has deprecated the global `on_fetch` handler. The terminal throws: `Uncaught Error: Handler does not export a fetch() function.`

### Root Cause
`workers/main.py` was using the outdated global function syntax instead of the modern class-based structure required by current Cloudflare Worker environments.

### Fix
- Migrated the main entry point to use `class Default(WorkerEntrypoint)` extending from the `workers` module.
- Updated the routing call to use `self.env` to properly pass bindings in the new class context.

Local development now correctly spins up the worker and serves `200 OK` for valid database routes.

Fixes #114 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of the worker request handling architecture with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->