### PR TITLE
fix: update actions/setup-node from v5 to v4

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: npm


### PR DESCRIPTION
Closes #130

## Summary
- Updated `actions/setup-node` from `v5` to `v4` in the CI workflow

## Why
`v4` is the current stable release recommended by GitHub. `v5` is a pre-release version and should not be used in production CI workflows as it can introduce unexpected breaking changes.

## Test plan
- [ ] CI workflow runs successfully with `actions/setup-node@v4`