### PR TITLE
fix: add timeout-minutes to CI validate job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Closes #131

## Summary
- Added `timeout-minutes: 10` to the `validate` job in the CI workflow

## Why
Without a timeout, a hung job (e.g. due to a stuck process) will consume GitHub Actions minutes indefinitely until GitHub's default 6-hour limit is hit. Setting an explicit timeout fails fast and saves resources.

## Test plan
- [ ] CI workflow still runs and completes within the timeout window
- [ ] Hung jobs will now be cancelled after 10 minutes