### PR TITLE
ci: add 15-minute timeout to validate job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Closes #146

## Summary
- Adds `timeout-minutes: 15` to the `validate` job in `ci-cd.yml`

Without this, a hung step defaults to GitHub's 360-minute limit, wasting runner resources and delaying feedback to contributors.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Confirm the `validate` job shows a 15-minute timeout cap in the Actions UI