### PR TITLE
ci: add workflow_dispatch trigger to CI workflows

### DIFF
--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -3,6 +3,7 @@ name: Check PR Conflicts
 # Uses pull_request_target so it runs with base repo permissions for forked PRs.
 # SECURITY: We do NOT check out or execute PR code. We only use the GitHub API.
 on:
+  workflow_dispatch:
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [main]


### PR DESCRIPTION
Closes #147

## Summary
- Adds `workflow_dispatch:` to `ci-cd.yml` and `check-pr-conflicts.yml`

This allows maintainers to trigger both workflows manually from the GitHub Actions UI without needing to push a commit or open a PR — useful for debugging flaky steps or re-verifying fixes.

## Test plan
- [ ] Confirm both workflows appear under the "Run workflow" button in the Actions tab