### PR TITLE
ci: add concurrency group to check-pr-conflicts workflow

### DIFF
--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -15,6 +15,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: conflict-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_conflicts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #148

## Summary
- Adds a `concurrency` block to `check-pr-conflicts.yml` to cancel in-progress runs when a new one is triggered on the same PR

The `ci-cd.yml` workflow already has this protection. Without it, rapid pushes to the same PR can trigger parallel conflict-check runs that race to add/remove labels and comments.

## Test plan
- [ ] Push two commits to a PR in quick succession and verify only one conflict-check run completes