### PR TITLE
ci: fix misleading step name for Python setup

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run tests (if configured)
         run: npm test --if-present
 
-      - name: Check Python worker syntax
+      - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"


### PR DESCRIPTION
Closes #150

## Summary
- Renames the step `"Check Python worker syntax"` → `"Setup Python"` in `ci-cd.yml`

`actions/setup-python` is a setup action — it installs Python into the runner. It performs no syntax checking. The actual check is done by the next step (`python -m py_compile`). The misleading name makes it harder to diagnose failures (e.g. a network error downloading Python looks like a syntax check failure).

## Test plan
- [ ] Verify CI passes and the step appears correctly named in the Actions run log