### PR TITLE
chore: add Dependabot config for GitHub Actions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Closes #151

## Summary
- Adds `.github/dependabot.yml` with a weekly schedule for `github-actions` ecosystem

Without this, action versions (`actions/checkout`, `actions/setup-node`, `actions/setup-python`, `actions/github-script`) are never updated automatically. Outdated actions can have known vulnerabilities that go unpatched indefinitely.

## Test plan
- [ ] Verify Dependabot appears as enabled under repository Settings → Code security and analysis
- [ ] Confirm Dependabot PRs start appearing on the weekly schedule